### PR TITLE
fix: correct French README translation and sync with English

### DIFF
--- a/Localization/README-FR.md
+++ b/Localization/README-FR.md
@@ -1,7 +1,7 @@
 <div align="center"><a href="https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/releases/latest"><img src="https://img.shields.io/github/v/release/UncomplicatedCustomServer/UncomplicatedCustomRoles"></a> <a href="https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/releases/latest"><img src="https://img.shields.io/github/downloads/UncomplicatedCustomServer/UncomplicatedCustomRoles/total"></a> <a href="https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/pulls"><img src="https://img.shields.io/github/issues-pr/UncomplicatedCustomServer/UncomplicatedCustomRoles"></a> <a href="https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/pulls"><img src="https://img.shields.io/github/issues-pr-closed/UncomplicatedCustomServer/UncomplicatedCustomRoles"></a> <img src="https://img.shields.io/badge/Verified_Exiled_Plugin-ss">
 
   <h1>UncomplicatedCustomRoles</h1>
-  <i>Rôles personnalisés, entièrement configurables et personnalisable pour votre serveur SCP!</i>
+  <i>Rôles personnalisés, entièrement configurables et personnalisables pour votre serveur SCP!</i>
 
   <br><br>
     <img src="https://ucs.fcosma.it/api/v2/ucr/graph/black">
@@ -10,38 +10,46 @@
   <br><br>
 </div>
 
-**EXILED** >= `v8.12`
+**EXILED** >= `v9.x`
 <br><br>
 
-## README Traduis
+## READMEs Traduits
 - [**Original** (Anglais)](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/blob/main/README.md)
-- [Italien](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/blob/main/Localization/README-IT.md)
-- [Russe](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/blob/main/Localization/README-RU.md)
+- [&#x1F1EE;&#x1F1F9; Italien](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/blob/main/Localization/README-IT.md)
+- [&#127479;&#127482; Russe](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/blob/main/Localization/README-RU.md)
+- [&#127465;&#127466; Allemand](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/blob/main/Localization/README-DE.md)
+- [&#127477;&#127473; Polonais](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/blob/main/Localization/README-PL.md)
+- [🇨🇳 Chinois simplifié](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/blob/main/Localization/README-CN.md)
 
 ## Qu'est ce que c'est UncomplicatedCustomRoles ?
-**UncomplicatedCustomRoles** ou **UCR** est un plugin pour [EXILED](https://github.com/Exiled-Team/EXILED) qui vous permet de créer des rôles personnalisé complètement customisable et configurable avec du YAML.\
-Vous serez capable de configurer le <ins>rôle</ins>, le <ins>nombre de point de vie (PV)</ins>, le <ins>rôle obtensible après s'être echapper</ins> et bien plus. 
+**UncomplicatedCustomRoles** ou **UCR** est un plugin pour [EXILED](https://github.com/Exiled-Team/EXILED) qui vous permet de créer des rôles personnalisés, complètement personnalisables et configurables avec du YAML.\
+Vous serez capable de configurer le <ins>rôle</ins>, le <ins>nombre de points de vie (PV)</ins>, le <ins>rôle obtenable après s'être échappé</ins> et bien plus.
 
 ## Fonctionnalités / Caractéristiques
-**UCR** a plusieurs fonctionnalités tel que:
-- Un nombre illimité de rôles personnalisable
-- Une config qui est séparé dans un autre fichier, pas le fichier config de Exiled (Celui par défaut)
-- Un [wiki](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/wiki) complet et compréhensible (Il est en Anglais)
-- Pas de dépandance requise
+**UCR** a plusieurs fonctionnalités telles que:
+- Un nombre illimité de rôles personnalisables
+- Une config qui est séparée dans un autre fichier, pas le fichier config d'EXILED (celui par défaut)
+- Un [wiki](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/wiki) complet et compréhensible
 - Une communauté active sur **Discord**
-- __Des privileges et des aperçus spéciaux__ pour les owners des serveurs utilisant UCR
-- Des commandes en jeu qui vous permettent de manipuler le plugin + vos rôles personnalisé
+- __Des privilèges et des aperçus spéciaux__ pour les owners des serveurs utilisant UCR
+- Des commandes en jeu qui vous permettent de manipuler le plugin + vos rôles personnalisés
+
 ## Installation
-Telecharger le `UncomplicatedCustomRoles.dll` içi [latest release](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/releases/latest) et mettez le dans `EXILED/Plugins` folder.
+Télécharger le `UncomplicatedCustomRoles.dll` ici depuis la [latest release](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/releases/latest) et mettez-le dans le dossier `EXILED/Plugins`.
 
 ## Développeurs
 UncomplicatedCustomRoles dispose d'une API simple et rapide pour les développeurs qui utilisent le plugin.
-Nous avons créer plein d'exemples dans le [developers wiki](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/wiki/Developers-World) (Qui est aussi en Anglais)
+Nous avons créé plein d'exemples dans le [developers wiki](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/wiki/Developers-World) (qui est aussi en Anglais)
 
 ## Vous avez du mal ? (Skill issue)
-Lisez le [WIKI](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/wiki) et si vous n'arrivez toujours pas à regler le problème, demander sur notre serveur Discord. La communauté vous aidera [Discord server](https://discord.gg/5StRGu8EJV)!
+Lisez le [WIKI](https://github.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/wiki) et si vous n'arrivez toujours pas à régler le problème, demandez sur notre serveur Discord. La communauté vous aidera [Discord server](https://discord.gg/5StRGu8EJV)!
 
-## Contactes
+## Pensez à faire un don à UncomplicatedCustomServer Collective
+Chaque plugin que nous créons est **gratuit** et **open-source**.\
+Pensez à faire un don pour soutenir notre travail via **OpenCollective** :
+<a href="https://opencollective.com/ucs"><img height="15" src="https://raw.githubusercontent.com/UncomplicatedCustomServer/UncomplicatedCustomRoles/refs/heads/resources/oc_icon.png">&nbsp;&nbsp;Faire un don</a>
+
+## Contacts
 ### UncomplicatedCustomRoles
   **Discord:** [https://discord.gg/5StRGu8EJV](https://discord.gg/5StRGu8EJV)
 


### PR DESCRIPTION
## Summary
- Fixed 17 spelling, grammar and agreement errors in `Localization/README-FR.md`
- Updated EXILED version reference (`v8.12` → `v9.x`)
- Added missing language links (DE, PL, CN) in the localized READMEs section
- Removed outdated "no dependency required" bullet point (removed from English README)
- Added missing donation section (translated from English)
- Fixed verb conjugations, missing accents and gender agreements throughout
